### PR TITLE
Creating Tracking Endpoint Object

### DIFF
--- a/lib/fedex_rest_api.rb
+++ b/lib/fedex_rest_api.rb
@@ -5,6 +5,7 @@ require "debug"
 class FedexRestApi
   require "fedex_rest_api/auth"
   require "fedex_rest_api/track"
+  require "fedex_rest_api/tracking_object"
   require "fedex_rest_api/address"
 
   class ApiError < StandardError; end

--- a/lib/fedex_rest_api/base.rb
+++ b/lib/fedex_rest_api/base.rb
@@ -2,6 +2,7 @@
 
 class FedexRestApi::Base
   PRODUCTION_ENV = "production"
+  SANDBOX = "sandbox"
 
   SANDBOX_URL = "https://apis-sandbox.fedex.com"
   PRODUCTION_URL = "https://apis.fedex.com"

--- a/lib/fedex_rest_api/track.rb
+++ b/lib/fedex_rest_api/track.rb
@@ -7,7 +7,7 @@ class FedexRestApi::Track
 
   TRACK_URL = "/track/v1/trackingnumbers"
 
-  def initialize(tracking_object, environment: nil)
+  def initialize(tracking_object, environment: FedexRestApi::Base::SANDBOX)
     @tracking_object = tracking_object
     @environment = environment
   end

--- a/lib/fedex_rest_api/track.rb
+++ b/lib/fedex_rest_api/track.rb
@@ -3,12 +3,13 @@
 require "fedex_rest_api/base"
 
 class FedexRestApi::Track
-  attr_reader :tracking_object
+  attr_reader :tracking_object, :environment
 
   TRACK_URL = "/track/v1/trackingnumbers"
 
-  def initialize(tracking_object)
+  def initialize(tracking_object, environment: nil)
     @tracking_object = tracking_object
+    @environment = environment
   end
 
   def track
@@ -28,7 +29,7 @@ class FedexRestApi::Track
   end
 
   def env_url
-    if tracking_object[:environment] == FedexRestApi::Base::PRODUCTION_ENV
+    if environment == FedexRestApi::Base::PRODUCTION_ENV
       "#{FedexRestApi::Base::PRODUCTION_URL}#{TRACK_URL}"
     else
       "#{FedexRestApi::Base::SANDBOX_URL}#{TRACK_URL}"

--- a/lib/fedex_rest_api/track.rb
+++ b/lib/fedex_rest_api/track.rb
@@ -15,11 +15,11 @@ class FedexRestApi::Track
     response = HTTParty.post(env_url,
       headers: {
         "Content-Type" => 'application/json',
-        "Authorization" => "Bearer #{tracking_object[:access_token]}"
+        "Authorization" => "Bearer #{tracking_object.access_token}"
       },
       body: {
-        "includeDetailedScans": tracking_object[:include_detailed_scans],
-        "trackingInfo": tracking_object[:tracking_numbers]
+        "includeDetailedScans": tracking_object.include_detailed_scans,
+        "trackingInfo": tracking_object.tracking_numbers
       }.to_json
     )
 

--- a/lib/fedex_rest_api/tracking_object.rb
+++ b/lib/fedex_rest_api/tracking_object.rb
@@ -4,22 +4,18 @@ class FedexRestApi::TrackingObject
   attr_reader :access_token, :include_detailed_scans, :trackable_numbers
 
   def initialize(tracking_params)
-    @access_token = tracking_params[:access_token] || ""
+    @access_token = tracking_params[:access_token]
     @include_detailed_scans = tracking_params[:include_detailed_scans] || false
     @trackable_numbers = tracking_params[:trackable_numbers] || []
   end
 
   def tracking_numbers
-    tracking_objects = []
-
-    trackable_numbers.each do |tracking_number|
+    trackable_numbers.map do |tracking_number|
       tracking_objects << {
         "trackingNumberInfo": {
           "trackingNumber": tracking_number
         }
       }
     end
-
-    tracking_objects
   end
 end

--- a/lib/fedex_rest_api/tracking_object.rb
+++ b/lib/fedex_rest_api/tracking_object.rb
@@ -1,23 +1,25 @@
 require "fedex_rest_api/base"
-require "debug"
 
 class FedexRestApi::TrackingObject
-  attr_reader :tracking_params
+  attr_reader :access_token, :include_detailed_scans, :trackable_numbers
 
   def initialize(tracking_params)
-    @tracking_params = tracking_params
-    binding.break
-  end
-
-  def access_token
-    tracking_object[:access_token]
-  end
-
-  def include_detailed_scans
-    tracking_object[:include_detailed_scans]
+    @access_token = tracking_params[:access_token] || ""
+    @include_detailed_scans = tracking_params[:include_detailed_scans] || false
+    @trackable_numbers = tracking_params[:trackable_numbers] || []
   end
 
   def tracking_numbers
-    tracking_object[:tracking_numbers]
+    tracking_objects = []
+
+    trackable_numbers.each do |tracking_number|
+      tracking_objects << {
+        "trackingNumberInfo": {
+          "trackingNumber": tracking_number
+        }
+      }
+    end
+
+    tracking_objects
   end
 end

--- a/lib/fedex_rest_api/tracking_object.rb
+++ b/lib/fedex_rest_api/tracking_object.rb
@@ -1,0 +1,23 @@
+require "fedex_rest_api/base"
+require "debug"
+
+class FedexRestApi::TrackingObject
+  attr_reader :tracking_params
+
+  def initialize(tracking_params)
+    @tracking_params = tracking_params
+    binding.break
+  end
+
+  def access_token
+    tracking_object[:access_token]
+  end
+
+  def include_detailed_scans
+    tracking_object[:include_detailed_scans]
+  end
+
+  def tracking_numbers
+    tracking_object[:tracking_numbers]
+  end
+end

--- a/spec/track/track_spec.rb
+++ b/spec/track/track_spec.rb
@@ -4,7 +4,8 @@ require "fedex_rest_api/track"
 
 RSpec.describe FedexRestApi::Track do
   let(:auth) { FedexRestApi::Auth.new(fedex_tracking_credentials).fetch_token }
-  let(:fedex) { FedexRestApi::Track.new({access_token: auth["access_token"], include_detailed_scans: true, tracking_numbers: tracking_numbers}) }
+  let(:fedex) { FedexRestApi::Track.new(tracking_object) }
+  let(:tracking_object) { FedexRestApi::TrackingObject.new({access_token: auth["access_token"], include_detailed_scans: true, trackable_numbers: [794843185271, 449044304137821]}) }
 
   context "with a valid access token", :vcr do
     describe "when a request is submitted with one or more valid tracking numbers" do
@@ -18,22 +19,8 @@ RSpec.describe FedexRestApi::Track do
 
   context "with an invalid or expired access token", :vcr do
     it "raises an error" do
-      expect{FedexRestApi::Track.new({access_token: "123"}).track}.to raise_error(FedexRestApi::ApiError)
+      tracking_object = FedexRestApi::TrackingObject.new({access_token: "123"})
+      expect{FedexRestApi::Track.new(tracking_object).track}.to raise_error(FedexRestApi::ApiError)
     end
   end
-end
-
-def tracking_numbers
-  [
-    {
-      "trackingNumberInfo": {
-        "trackingNumber": 794843185271
-      }
-    },
-    {
-      "trackingNumberInfo": {
-        "trackingNumber": 449044304137821
-      }
-    }
-  ]
 end

--- a/spec/vcr/fedex_rest_api_track/with_a_valid_access_token_when_a_request_is_submitted_with_one_or_more_valid_tracking_numbers_returns_a_valid_response.yml
+++ b/spec/vcr/fedex_rest_api_track/with_a_valid_access_token_when_a_request_is_submitted_with_one_or_more_valid_tracking_numbers_returns_a_valid_response.yml
@@ -33,20 +33,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 16 Apr 2024 20:39:12 GMT
+      - Mon, 22 Apr 2024 16:56:56 GMT
       Content-Length:
       - '1353'
       Connection:
       - keep-alive
       Server-Timing:
-      - ak_p; desc="1713299952003_389030153_317854426_37168_7257_15_32_-";dur=1
+      - ak_p; desc="1713805015716_389030169_101993773_35448_9745_14_30_-";dur=1
       - cdn-cache; desc=MISS
-      - edge; dur=42
-      - origin; dur=330
+      - edge; dur=44
+      - origin; dur=311
     body:
       encoding: UTF-8
       string: "<ACCESS OBJECT>"
-  recorded_at: Tue, 16 Apr 2024 20:39:12 GMT
+  recorded_at: Mon, 22 Apr 2024 16:56:56 GMT
 - request:
     method: post
     uri: https://apis-sandbox.fedex.com/track/v1/trackingnumbers
@@ -78,18 +78,18 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 16 Apr 2024 20:39:12 GMT
+      - Mon, 22 Apr 2024 16:56:56 GMT
       Content-Length:
       - '8681'
       Connection:
       - keep-alive
       Server-Timing:
-      - ak_p; desc="1713299952477_389030153_317854822_19932_5866_14_44_-";dur=1
+      - ak_p; desc="1713805016153_389030169_101994269_19682_7243_13_18_-";dur=1
       - cdn-cache; desc=MISS
-      - edge; dur=29
-      - origin; dur=170
+      - edge; dur=9
+      - origin; dur=188
     body:
       encoding: ASCII-8BIT
       string: "<ACCESS OBJECT>"
-  recorded_at: Tue, 16 Apr 2024 20:39:12 GMT
+  recorded_at: Mon, 22 Apr 2024 16:56:56 GMT
 recorded_with: VCR 6.2.0

--- a/spec/vcr/fedex_rest_api_track/with_an_invalid_or_expired_access_token_raises_an_error.yml
+++ b/spec/vcr/fedex_rest_api_track/with_an_invalid_or_expired_access_token_raises_an_error.yml
@@ -29,16 +29,16 @@ http_interactions:
       Server:
       - Layer7-API-Gateway
       Date:
-      - Tue, 16 Apr 2024 20:39:12 GMT
+      - Mon, 22 Apr 2024 16:56:56 GMT
       Connection:
       - close
       Server-Timing:
-      - ak_p; desc="1713299952771_389030153_317855063_14302_7065_12_19_-";dur=1
+      - ak_p; desc="1713805016420_389030169_101994621_20040_5536_11_18_-";dur=1
       - cdn-cache; desc=MISS
-      - edge; dur=38
-      - origin; dur=105
+      - edge; dur=8
+      - origin; dur=193
     body:
       encoding: UTF-8
       string: "<ACCESS OBJECT>"
-  recorded_at: Tue, 16 Apr 2024 20:39:12 GMT
+  recorded_at: Mon, 22 Apr 2024 16:56:56 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
Related to: https://github.com/Home-Chef-Tech/ops-tech/issues/6492

A follow up from some recent work - we've decided to 'formalize' the arguments coming in to now use an proper object (as opposed to a freehand object). Gives us a little more flexibility and greater visibility into the data (and it's shape) that's required to complete a request to FedEx's API. 