### PR TITLE
Address Verification Object

### DIFF
--- a/lib/fedex_rest_api.rb
+++ b/lib/fedex_rest_api.rb
@@ -7,6 +7,7 @@ class FedexRestApi
   require "fedex_rest_api/track"
   require "fedex_rest_api/tracking_object"
   require "fedex_rest_api/address"
+  require "fedex_rest_api/address_object"
 
   class ApiError < StandardError; end
 end

--- a/lib/fedex_rest_api/address.rb
+++ b/lib/fedex_rest_api/address.rb
@@ -3,22 +3,24 @@
 require "fedex_rest_api/base"
 
 class FedexRestApi::Address
-  attr_reader :address_object
+  attr_reader :address_object, :environment
 
   ADDRESS_VALIDATION_URL = "/address/v1/addresses/resolve"
 
-  def initialize(address_object)
+  def initialize(address_object, environment: FedexRestApi::Base::SANDBOX)
     @address_object = address_object
+    @environment = environment
   end
 
   def validate
+    binding.break
     response = HTTParty.post(env_url,
       headers: {
         "Content-Type" => 'application/json',
-        "Authorization" => "Bearer #{address_object[:access_token]}"
+        "Authorization" => "Bearer #{address_object.access_token}"
       },
       body: {
-        "addressesToValidate": address_object[:addresses]
+        "addressesToValidate": address_object.addresses
       }.to_json
     )
 
@@ -27,7 +29,7 @@ class FedexRestApi::Address
   end
 
   def env_url
-    if address_object[:environment] == FedexRestApi::Base::PRODUCTION_ENV
+    if environment == FedexRestApi::Base::PRODUCTION_ENV
       "#{FedexRestApi::Base::PRODUCTION_URL}#{ADDRESS_VALIDATION_URL}"
     else
       "#{FedexRestApi::Base::SANDBOX_URL}#{ADDRESS_VALIDATION_URL}"

--- a/lib/fedex_rest_api/address.rb
+++ b/lib/fedex_rest_api/address.rb
@@ -13,7 +13,6 @@ class FedexRestApi::Address
   end
 
   def validate
-    binding.break
     response = HTTParty.post(env_url,
       headers: {
         "Content-Type" => 'application/json',

--- a/lib/fedex_rest_api/address_object.rb
+++ b/lib/fedex_rest_api/address_object.rb
@@ -1,0 +1,24 @@
+require "fedex_rest_api/base"
+
+class FedexRestApi::AddressObject
+  attr_reader :access_token, :addresses
+
+  def initialize(address_params)
+    @access_token = address_params[:access_token]
+    @addresses = address_params[:addresses] || []
+  end
+
+  def address_objects
+    addresses.map do |address|
+      {
+        address: {
+          "streetLines": [address.string(nil, format: :short)],
+          "city": address.city,
+          "stateOrProvinceCode": address.state,
+          "postalCode": address.zip,
+          "countryCode": "USA"
+        }
+      }
+    end
+  end
+end

--- a/lib/fedex_rest_api/address_object.rb
+++ b/lib/fedex_rest_api/address_object.rb
@@ -1,22 +1,22 @@
 require "fedex_rest_api/base"
 
 class FedexRestApi::AddressObject
-  attr_reader :access_token, :addresses
+  attr_reader :access_token, :addresses_to_validate
 
   def initialize(address_params)
     @access_token = address_params[:access_token]
-    @addresses = address_params[:addresses] || []
+    @addresses_to_validate = address_params[:addresses] || []
   end
 
-  def address_objects
-    addresses.map do |address|
+  def addresses
+    addresses_to_validate.map do |address|
       {
         address: {
-          "streetLines": [address.string(nil, format: :short)],
-          "city": address.city,
-          "stateOrProvinceCode": address.state,
-          "postalCode": address.zip,
-          "countryCode": "USA"
+          "streetLines": [address[:street]],
+          "city": address[:city],
+          "stateOrProvinceCode": address[:state],
+          "postalCode": address[:zip],
+          "countryCode": "US"
         }
       }
     end


### PR DESCRIPTION
Related to: https://github.com/Home-Chef-Tech/ops-tech/issues/6494

Adds in the initial classes to build out an Address Object. We can send through a total of 100 addresses in the `addressesToValidate` array. The Object class will be leveraged to bundle up those nested items to be sent through. 