### PR TITLE
Request Cleanup

### DIFF
--- a/lib/fedex_rest_api/address_object.rb
+++ b/lib/fedex_rest_api/address_object.rb
@@ -12,11 +12,11 @@ class FedexRestApi::AddressObject
     addresses_to_validate.map do |address|
       {
         address: {
-          "streetLines": [address[:street]],
-          "city": address[:city],
-          "stateOrProvinceCode": address[:state],
-          "postalCode": address[:zip],
-          "countryCode": "US"
+          streetLines: address[:address][:street],
+          city: address[:address][:city],
+          stateOrProvinceCode: address[:address][:state],
+          postalCode: address[:address][:zip],
+          countryCode: address[:address][:country]
         }
       }
     end


### PR DESCRIPTION
Small updates to match the desired shape of FedEx's API request.

Special note: The endpoint can take in up to 100 addresses in a single request. This is built out with that in mind  - however, Mealhand will only send through one address at a time. 