### PR TITLE
Remove Residential & Add Error Description

### DIFF
--- a/lib/fedex_rest_api/shipment.rb
+++ b/lib/fedex_rest_api/shipment.rb
@@ -21,7 +21,8 @@ class FedexRestApi::Shipment
       body: shipment_object.body.to_json
     )
 
-    raise FedexRestApi::ApiError.new(response) if response["errors"]
+    error_message = response['errors'] || response['error_description']
+    raise FedexRestApi::ApiError.new(error_message) if error_message
     response
   end
 

--- a/lib/fedex_rest_api/shipment_object.rb
+++ b/lib/fedex_rest_api/shipment_object.rb
@@ -83,8 +83,7 @@ class FedexRestApi::ShipmentObject
         city: location[:address][:city],
         stateOrProvinceCode: location[:address][:state_or_province_code],
         postalCode: location[:address][:postal_code],
-        countryCode: location[:address][:country_code],
-        residential: location[:address][:residential] || false
+        countryCode: location[:address][:country_code]
       },
       contact: {
         phoneNumber: location[:contact][:phone_number],


### PR DESCRIPTION
This addresses a few things I missed in the last PR.  Here is the FedEx api: https://developer.fedex.com/api/en-us/catalog/ship/v1/docs.html

* We are now adding the error or error description to the error object when an error is raised, and
* We are removing the residential key from our request.

After this commit, we will then tag it officially as 0.2.1

As you can see from the docs, we are looking for the key `errors`, but the vcr has error_description.

<img width="487" height="420" alt="Screenshot 2026-04-02 at 11 31 08 AM" src="https://github.com/user-attachments/assets/3e5c954a-9577-4eab-a174-e1bbe4e95ed8" />